### PR TITLE
Better cookie options and README clarification

### DIFF
--- a/src/app/using-hosted-authkit/README.md
+++ b/src/app/using-hosted-authkit/README.md
@@ -21,7 +21,7 @@ In order to test Single Sign-On, you will need to create an organization in your
 - [Basic authentication](./basic/page.tsx). How to use AuthKit's hosted UI with any authentication method (Email + Password, Magic Auth, Google OAuth, Microsoft OAuth, and Single Sign-On).
 - [With client-side sessions](./with-session/page.tsx). How to use AuthKit's hosted UI and manage sessions client-side using JavaScript Web Tokens (JWTs).
 
-For the example with session, you will need to add a JWT secret as an environment variable. It can be any random string for testing locally, but as a best practice let's generate a secret key from the command line using the node crypto module:
+For the example with session, you will need to add a JWT secret as an environment variable. It can be any random base64 string for testing locally, but as a best practice let's generate a secret key from the command line using the node crypto module:
 
 ```bash
 node -e "console.log(require('crypto').randomBytes(64).toString('base64'));"

--- a/src/app/using-hosted-authkit/with-session/callback/route.ts
+++ b/src/app/using-hosted-authkit/with-session/callback/route.ts
@@ -41,6 +41,8 @@ export async function GET(request: Request) {
       value: token,
       httpOnly: true,
       path: '/',
+      secure: true,
+      sameSite: 'lax',
     });
 
     return response;


### PR DESCRIPTION
* samesite: lax is the default in browsers, but getting explicit
* secure: https only (doesn't affect localhost)
* clarifies in the README that the secret should be base64 (this is what we expect in our callback)
