### PR TITLE
Add GithubOAuth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ http://localhost:3000/using-your-own-ui/sign-in/microsoft-oauth/callback
 ```
 
 ```bash
+http://localhost:3000/using-your-own-ui/sign-in/github-oauth/callback
+```
+
+```bash
 http://localhost:3000/using-your-own-ui/sign-in/sso/callback
 ```
 

--- a/src/app/using-your-own-ui/page.tsx
+++ b/src/app/using-your-own-ui/page.tsx
@@ -24,6 +24,9 @@ export default function UsingYourOwnUi() {
           <Link href="/using-your-own-ui/sign-in/magic-auth">Magic Auth</Link>
         </li>
         <li>
+          <Link href="/using-your-own-ui/sign-in/github-oauth">GitHub OAuth</Link>
+        </li>
+        <li>
           <Link href="/using-your-own-ui/sign-in/google-oauth">Google OAuth</Link>
         </li>
         <li>

--- a/src/app/using-your-own-ui/sign-in/github-oauth/callback/route.ts
+++ b/src/app/using-your-own-ui/sign-in/github-oauth/callback/route.ts
@@ -1,0 +1,37 @@
+import { WorkOS } from '@workos-inc/node';
+import { redirect } from 'next/navigation';
+
+// This is a Next.js Route Handler.
+//
+// If your application is a single page app (SPA) with a separate backend you will need to:
+// - create a backend endpoint to handle the request
+// - adapt the code below in your endpoint
+//
+// Please also note that for the sake of simplicity, we directly return the user here in the query string.
+// In a real application, you would probably store the user in a token (JWT)
+// and store that token in your DB or use cookies.
+
+const workos = new WorkOS(process.env.WORKOS_API_KEY);
+
+export async function GET(request: Request) {
+  const code = new URL(request.url).searchParams.get('code') || '';
+
+  let response;
+
+  try {
+    response = await workos.userManagement.authenticateWithCode({
+      clientId: process.env.WORKOS_CLIENT_ID || '',
+      code,
+    });
+  } catch (error) {
+    response = error;
+  }
+
+  if (response) {
+    redirect(
+      `http://localhost:3000/using-your-own-ui/sign-in/github-oauth?response=${JSON.stringify(
+        response
+      )}`
+    );
+  }
+}

--- a/src/app/using-your-own-ui/sign-in/github-oauth/page.tsx
+++ b/src/app/using-your-own-ui/sign-in/github-oauth/page.tsx
@@ -1,0 +1,35 @@
+import { WorkOS } from '@workos-inc/node';
+
+// This example uses Next.js with React Server Components.
+// Because this page is an RSC, the code stays on the server, which allows
+// us to use the WorkOS Node SDK without exposing our API key to the client.
+//
+// If your application is a single page app (SPA), you will need to:
+// - create a form that can POST to an endpoint in your backend
+// - call the `getAuthorizationURL` method in that endpoint
+// - redirect the user to the returned URL
+
+const workos = new WorkOS(process.env.WORKOS_API_KEY);
+
+export default function SignInWithGitHubOAuth({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const githubOAuthUrl = workos.userManagement.getAuthorizationUrl({
+    clientId: process.env.WORKOS_CLIENT_ID || '',
+    provider: 'GitHubOAuth',
+    redirectUri: 'http://localhost:3000/using-your-own-ui/sign-in/github-oauth/callback',
+  });
+
+  const result = JSON.parse(String(searchParams.response ?? '{ "error": null }'));
+
+  return (
+    <main>
+      <h1>Sign-in</h1>
+      <h2>GitHub OAuth</h2>
+      <a href={githubOAuthUrl}>Continue with GitHub</a>
+      <pre>{JSON.stringify(result, null, 2)}</pre>
+    </main>
+  );
+}


### PR DESCRIPTION
This is identical to the {Google,Microsoft}OAuth examples.

We should consider adding some handling of the `existing_user` error case to these.
